### PR TITLE
Fix Discord on newer versions of Electron

### DIFF
--- a/src/utils/requireNative.js
+++ b/src/utils/requireNative.js
@@ -1,18 +1,10 @@
 // From Discord to only require native modules like discord_desktop_core
 const path = require("path");
-const fs = require("fs");
-const paths = require("../paths");
+const Module = require("module");
 
 module.paths = [];
 module.exports = (name) => {
-	const modulesPath = path.join(paths.getExeDir(), "modules");
-	const folders = fs
-		.readdirSync(modulesPath)
-		.filter((f) => fs.statSync(path.join(modulesPath, f)).isDirectory());
-	for (const folder of folders) {
-		if (folder.startsWith(name)) {
-			return require(path.join(modulesPath, folder, name));
-		}
-	}
+	const mod = Module.globalPaths.find((p) => p.includes(name));
+	if (mod) return require(path.join(mod, name));
 	throw `Module ${name} not found.`;
 };

--- a/src/utils/requireNative.js
+++ b/src/utils/requireNative.js
@@ -1,3 +1,18 @@
 // From Discord to only require native modules like discord_desktop_core
+const path = require("path");
+const fs = require("fs");
+const paths = require("../paths");
+
 module.paths = [];
-module.exports = require;
+module.exports = (name) => {
+	const modulesPath = path.join(paths.getExeDir(), "modules");
+	const folders = fs
+		.readdirSync(modulesPath)
+		.filter((f) => fs.statSync(path.join(modulesPath, f)).isDirectory());
+	for (const folder of folders) {
+		if (folder.startsWith(name)) {
+			return require(path.join(modulesPath, folder, name));
+		}
+	}
+	throw `Module ${name} not found.`;
+};


### PR DESCRIPTION
In Electron 17 and up *something* changed relating to `require` so it's now *require*d to specify the exact path here or Discord will not open. It's possible Discord will update eventually so this is a preemptive fix.