### PR TITLE
Add ability to inject JS into main window

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -30,14 +30,16 @@ const autoStart = require('./autoStart');
 
 let desktopCore;
 const startCore = () => {
-  if (oaConfig.removeCSP) {
-    session.defaultSession.webRequest.onHeadersReceived(({ responseHeaders }, callback) => {
-      for (const header in responseHeaders)
-        if (header.toLowerCase().startsWith("content-security-policy"))
-          delete responseHeaders[header];
+  if (oaConfig.jsInject) {
+    session.defaultSession.webRequest.onHeadersReceived(
+      ({ responseHeaders }, cb) => {
+        for (const header in responseHeaders)
+          if (header.toLowerCase().startsWith("content-security-policy"))
+            delete responseHeaders[header];
 
-      callback({ responseHeaders });
-    })
+        cb({ responseHeaders });
+      }
+    );
   }
 
   app.on('browser-window-created', (e, bw) => { // Main window injection
@@ -52,7 +54,7 @@ const startCore = () => {
           .replaceAll('<hash>', hash || 'custom')
       );
 
-      if (oaConfig.jsInject) 
+      if (oaConfig.jsInject)
         bw.webContents.executeJavaScript(oaConfig.jsInject)
     });
   });


### PR DESCRIPTION
This allows us to load a Javascript file from a URL and inject it into the Discord main window at load.

While not required for the use of this specifically, a common use case of loading a client mod would
most likely take advantage of the removal of content-security-policy headers, so this PR also adds this as an option.

Here is an example settings.json:
```json
{
  "openasar": {
    "jsInject": "https://github.com/GooseMod/GooseMod/releases/download/dev/index.js",
    "removeCSP": true
  }
}
```