### PR TITLE
Add logic needed to allow opening of settings.json

### DIFF
--- a/src/config/index.js
+++ b/src/config/index.js
@@ -30,4 +30,11 @@ exports.open = () => {
     app.relaunch();
     app.exit();
   });
+
+  ipcMain.on('of', () => {
+    const { shell } = require('electron')
+    const { getUserData } = require('../paths')
+    const {join} = require('path')
+      shell.openPath(join(getUserData(), 'settings.json'))
+  })
 };

--- a/src/config/preload.js
+++ b/src/config/preload.js
@@ -4,5 +4,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('Native', {
   restart: () => ipcRenderer.send('cr'),
   set: c => ipcRenderer.send('cs', c),
-  get: () => ipcRenderer.sendSync('cg')
+  get: () => ipcRenderer.sendSync('cg'),
+  openFile: () => ipcRenderer.send('of')
 });


### PR DESCRIPTION
This adds the logic needed in the electron backend to allow the user to open Settings.json from the OA settings modal 

This is the second part of what's needed to fulfill the feature request found [Here](https://github.com/GooseMod/OpenAsar/issues/29)

This is related to [This  PR](https://github.com/OpenAsar/cdn/pull/1)