### PR TITLE
Fix syntax error in injectPolyfills.sh

### DIFF
--- a/scripts/injectPolyfills.sh
+++ b/scripts/injectPolyfills.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo This script (injectPolyfills) only exists to stop older build scripts from breaking, you no longer need to run it
+echo "This script (injectPolyfills) only exists to stop older build scripts from breaking, you no longer need to run it."


### PR DESCRIPTION
The current `injectPolyfills.sh` placeholder fails with ```sh: syntax error near unexpected token `('```.