### PR TITLE
Fix broken customFlags handling in cleanup version

### DIFF
--- a/src/cmdSwitches.js
+++ b/src/cmdSwitches.js
@@ -9,7 +9,7 @@ const presets = {
 
 module.exports = () => {
   let c = {};
-  for (const x of ('base,' + (oaConfig.cmdPreset || 'perf')).split(',').reduce((a, x) => a.concat(presets[x]?.split(' '))).concat((oaConfig.customFlags ?? '').split(' '))) {
+  for (const x of ('base,' + (oaConfig.cmdPreset || 'perf')).split(',').reduce((a, x) => a.concat(presets[x]?.split(' ')), (oaConfig.customFlags ?? '').split(' '))) {
     if (!x) continue;
     const [ k, v ] = x.split('=');
 


### PR DESCRIPTION
Hi there,

I noticed that the cleanup of the code in commit [593b236](https://github.com/GooseMod/OpenAsar/commit/593b236711edc348c8640aabe6f68eeebcaccff2) inadvertently broke the customFlags feature due to a small logic error. In the minified version of the code, the customFlags were concatenated outside of the reduce function, causing the flags to be processed incorrectly.

I have fixed this issue in the minified version by moving the customFlags concatenation inside the reduce function. Here's the corrected code snippet:

```javascript
for (const x of ('base,' + (oaConfig.cmdPreset || 'perf')).split(',').reduce((a, x) => a.concat(presets[x]?.split(' ')), (oaConfig.customFlags ?? '').split(' '))) {
```
With this change, the customFlags feature should work correctly, and the minified version should function the same way as my original pull request.