### PR TITLE
Updated cmdSwitches.js for extra performance

### DIFF
--- a/src/cmdSwitches.js
+++ b/src/cmdSwitches.js
@@ -1,9 +1,9 @@
 const { app } = require('electron');
 
 const presets = {
-  'base': '--autoplay-policy=no-user-gesture-required --disable-features=WinRetrieveSuggestionsOnlyOnDemand,HardwareMediaKeyHandling,MediaSessionService', // Base Discord
-  'perf': `--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist --enable-hardware-overlays=single-fullscreen,single-on-top,underlay --enable-features=EnableDrDc,CanvasOopRasterization,BackForwardCache:TimeToLiveInBackForwardCacheInSeconds/300/should_ignore_blocklists/true/enable_same_site/true,ThrottleDisplayNoneAndVisibilityHiddenCrossOriginIframes,UseSkiaRenderer,WebAssemblyLazyCompilation --disable-features=Vulkan --force_high_performance_gpu`, // Performance
-  'battery': '--enable-features=TurnOffStreamingMediaCachingOnBattery --force_low_power_gpu' // Known to have better battery life for Chromium?
+  'base': '--disable-background-networking --autoplay-policy=no-user-gesture-required --disable-features=WinRetrieveSuggestionsOnlyOnDemand,HardwareMediaKeyHandling,MediaSessionService', // Base Discord
+  'perf': `--enable-gpu-rasterization --enable-zero-copy --ignore-gpu-blocklist --enable-hardware-overlays=single-fullscreen,single-on-top,underlay --enable-features=EnableDrDc,CanvasOopRasterization,BackForwardCache:TimeToLiveInBackForwardCacheInSeconds/300/should_ignore_blocklists/true/enable_same_site/true,ThrottleDisplayNoneAndVisibilityHiddenCrossOriginIframes,UseSkiaRenderer,WebAssemblyLazyCompilation --disable-low-end-device-mode --v8-cache-options=code --disable-features=Vulkan --force_high_performance_gpu `, // Performance
+  'battery': '--enable-features=TurnOffStreamingMediaCachingOnBattery --enable-low-end-device-mode --force_low_power_gpu' // Known to have better battery life for Chromium?
 };
 
 


### PR DESCRIPTION
Added the --disable-background-networking flag to the basic mode, added chromiums native v8 compile cache for peformance mode and also enabled/disabled low end device mode depending on performance/battery


Also would be cool for a 'gaming mode' which uses performance mode but omits the gpu performance features (to reduce the background GPU usage of discord),I was too lazy to implement this...