### PR TITLE
Add automated installation script for Linux

### DIFF
--- a/scripts/install-openasar.sh
+++ b/scripts/install-openasar.sh
@@ -13,86 +13,72 @@
 #
 #  Main program: 
 #  Checks for the existance of several common directories that Discord installs itself into.
-#  If one is found, it `cd`s into it and hands over to checkForExistingInstall.
+#  If one is found, it `cd`s into it and hands over to oAsarInstall.
 #
-#  checkForExistingInstall:
+#  oAsarInstall:
 #  If no current installation of OpenAsar is found (indicated by the abscence of an "app.asar.bak" file),
 #  the script renames the current "app.asar" to "app.asar.bak", then downloads OpenAsar from
 #  the nightly GitHub page (via wget) into the current working directory.
 #  A sudo prompt will appear to place OpenAsar into the directory.
-#
-#  If a current installation of OpenAsar DOES exist, the script will prompt the user asking if they want
-#  to replace it. If user says yes, the installation process will be executed.
+#  If a current installation of OpenAsar DOES exist, the script will replace it.
 
 
-checkForExistingInstall()
+oAsarInstall()
 {
-    echo
-    if [ -a "app.asar.bak" ] 
-        then
-            echo -n "OpenAsar is already installed in `pwd`. Would you like to replace it? [y/N] "
-            read -r PROMPT
-            if [ "$PROMPT" == 'y' ] || [ "$PROMPT" == 'Y' ]
-                then
-                sudo rm app.asar
-                sudo wget https://github.com/GooseMod/OpenAsar/releases/download/nightly/app.asar
-                echo
-                echo "OpenAsar has been installed! If Discord is still running, restart it."
+   echo
 
-                exit 0
-                else
-                exit 2
-            fi
-        else
-            sudo mv app.asar app.asar.bak
-            sudo wget https://github.com/GooseMod/OpenAsar/releases/download/nightly/app.asar
-            echo
-            echo "OpenAsar has been installed! If Discord is still running, restart it."
-            exit 0
-    fi
+   if [ -a "app.asar.bak" ]; then
+     sudo rm app.asar.bak
+   fi
+
+   sudo mv app.asar app.asar.bak
+   sudo wget https://github.com/GooseMod/OpenAsar/releases/download/nightly/app.asar
+   echo
+   echo "OpenAsar has been installed! If Discord is still running, restart it."
+   exit 0
 }
 
 echo "Checking file directories..."
 echo
-#Find which directory Discord is installed in. If it exists, move to checkForExistingInstall
+#Find which directory Discord is installed in. If it exists, move to oAsarInstall
 if [ -d "/opt/discord/resources/" ]; then
    cd /opt/discord/resources/
-   checkForExistingInstall
+   oAsarInstall
 else
    echo "/opt/discord/resources/ dosen't exist"
 fi
 
 if [ -d "/usr/lib/discord/resources/" ]; then
    cd /usr/lib/discord/resources/
-   checkForExistingInstall
+   oAsarInstall
 else
    echo "/usr/lib/discord/resources/ dosen't exist"
 fi
 
 if [ -d "/usr/lib64/discord/resources/" ]; then
    cd /usr/lib64/discord/resources/
-   checkForExistingInstall
+   oAsarInstall
 else
    echo "/usr/lib64/discord/resources/ dosen't exist"
 fi
 
 if [ -d "/usr/share/discord/resources/" ]; then
    cd /usr/share/discord/resources/
-   checkForExistingInstall
+   oAsarInstall
 else
    echo "/usr/share/discord/resources/ dosen't exist"
 fi
 
 if [ -d "/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/" ]; then
    cd /var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/
-   checkForExistingInstall
+   oAsarInstall
 else
    echo "/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/ dosen't exist"
 fi
 
 if [ -d "$HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/" ]; then
-   cd $HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/
-   checkForExistingInstall 
+   cd "$HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/"
+   oAsarInstall 
 else
    echo "$HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/ dosen't exist"
 fi

--- a/scripts/install-openasar.sh
+++ b/scripts/install-openasar.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+
+#   _______  _______  _______  _        _______  _______  _______  _______   
+#  (  ___  )(  ____ )(  ____ \( (    /|(  ___  )(  ____ \(  ___  )(  ____ )  
+#  | (   ) || (    )|| (    \/|  \  ( || (   ) || (    \/| (   ) || (    )|  
+#  | |   | || (____)|| (__    |   \ | || (___) || (_____ | (___) || (____)|  
+#  | |   | ||  _____)|  __)   | (\ \) ||  ___  |(_____  )|  ___  ||     __)  
+#  | |   | || (      | (      | | \   || (   ) |      ) || (   ) || (\ (     
+#  | (___) || )      | (____/\| )  \  || )   ( |/\____) || )   ( || ) \ \__  
+#  (_______)|/       (_______/|/    )_)|/     \|\_______)|/     \||/   \__/  
+#
+#  Installation Script for Linux.
+#
+#  Main program: 
+#  Checks for the existance of several common directories that Discord installs itself into.
+#  If one is found, it `cd`s into it and hands over to checkForExistingInstall.
+#
+#  checkForExistingInstall:
+#  If no current installation of OpenAsar is found (indicated by the abscence of an "app.asar.bak" file),
+#  the script renames the current "app.asar" to "app.asar.bak", then downloads OpenAsar from
+#  the nightly GitHub page (via wget) into the current working directory.
+#  A sudo prompt will appear to place OpenAsar into the directory.
+#
+#  If a current installation of OpenAsar DOES exist, the script will prompt the user asking if they want
+#  to replace it. If user says yes, the installation process will be executed.
+
+
+checkForExistingInstall()
+{
+    echo
+    if [ -a "app.asar.bak" ] 
+        then
+            echo -n "OpenAsar is already installed in `pwd`. Would you like to replace it? [y/N] "
+            read -r PROMPT
+            if [ "$PROMPT" == 'y' ] || [ "$PROMPT" == 'Y' ]
+                then
+                sudo rm app.asar
+                sudo wget https://github.com/GooseMod/OpenAsar/releases/download/nightly/app.asar
+                echo
+                echo "OpenAsar has been installed! If Discord is still running, restart it."
+
+                exit 0
+                else
+                exit 2
+            fi
+        else
+            sudo mv app.asar app.asar.bak
+            sudo wget https://github.com/GooseMod/OpenAsar/releases/download/nightly/app.asar
+            echo
+            echo "OpenAsar has been installed! If Discord is still running, restart it."
+            exit 0
+    fi
+}
+
+echo "Checking file directories..."
+echo
+#Find which directory Discord is installed in. If it exists, move to checkForExistingInstall
+if [ -d "/opt/discord/resources/" ]; then
+   cd /opt/discord/resources/
+   checkForExistingInstall
+else
+   echo "/opt/discord/resources/ dosen't exist"
+fi
+
+if [ -d "/usr/lib/discord/resources/" ]; then
+   cd /usr/lib/discord/resources/
+   checkForExistingInstall
+else
+   echo "/usr/lib/discord/resources/ dosen't exist"
+fi
+
+if [ -d "/usr/lib64/discord/resources/" ]; then
+   cd /usr/lib64/discord/resources/
+   checkForExistingInstall
+else
+   echo "/usr/lib64/discord/resources/ dosen't exist"
+fi
+
+if [ -d "/usr/share/discord/resources/" ]; then
+   cd /usr/share/discord/resources/
+   checkForExistingInstall
+else
+   echo "/usr/share/discord/resources/ dosen't exist"
+fi
+
+if [ -d "/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/" ]; then
+   cd /var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/
+   checkForExistingInstall
+else
+   echo "/var/lib/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/ dosen't exist"
+fi
+
+if [ -d "$HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/" ]; then
+   cd $HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/
+   checkForExistingInstall 
+else
+   echo "$HOME/.local/share/flatpak/app/com.discordapp.Discord/current/active/files/discord/resources/ dosen't exist"
+fi
+
+#None of the directory searches are successful
+echo "No Discord directories were found. Exiting..."
+exit 1
+


### PR DESCRIPTION
The purpose of this script is to automate the *tedious* task of clicking back and forth between the OpenAsar website and your file explorer of choice figuring out which directory Discord is installed in.

Effectively, installation on Linux would be as simple as running `wget -q -O - https://raw.githubusercontent.com/GooseMod/OpenAsar/main/scripts/install-openasar.sh | dos2unix | bash` in the terminal.
The wiki will be updated to reflect this new method of installation.