### PR TITLE
Fix #184: Use `electron/net` instead of `https` to download updates.

### DIFF
--- a/src/asarUpdate.js
+++ b/src/asarUpdate.js
@@ -1,4 +1,4 @@
-const { get } = require('https');
+const { get } = require('./utils/get');
 const fs = require('original-fs'); // Use original-fs, not Electron's modified fs
 const { join } = require('path');
 
@@ -6,29 +6,13 @@ const asarPath = join(__filename, '..');
 
 const asarUrl = `https://github.com/GooseMod/OpenAsar/releases/download/${oaVersion.split('-')[0]}/app.asar`;
 
-// todo: have these https utils centralised?
-const redirs = url => new Promise(res => get(url, r => { // Minimal wrapper around https.get to follow redirects
-  const loc = r.headers.location;
-  if (loc) return redirs(loc).then(res);
-
-  res(r);
-}));
-
 module.exports = async () => { // (Try) update asar
   if (!oaVersion.includes('-')) return;
   log('AsarUpdate', 'Updating...');
 
-  const res = (await redirs(asarUrl));
+  const buf = (await get(asarUrl))[1];
 
-  let data = [];
-  res.on('data', d => {
-    data.push(d);
-  });
+  if (!buf || !buf.toString('hex').startsWith('04000000')) return log('AsarUpdate', 'Download error'); // Request failed or ASAR header not present
 
-  res.on('end', () => {
-    const buf = Buffer.concat(data);
-    if (!buf.toString('hex').startsWith('04000000')) return log('AsarUpdate', 'Download error'); // Not like ASAR header
-
-    fs.writeFile(asarPath, buf, e => log('AsarUpdate', 'Downloaded', e ?? ''));
-  });
+  fs.writeFile(asarPath, buf, e => log('AsarUpdate', 'Downloaded', e ?? ''));
 };

--- a/src/utils/get.js
+++ b/src/utils/get.js
@@ -1,0 +1,17 @@
+const { net } = require('electron');
+
+// returns a promise that resolves to [statusCode, arrayBuffer, headers]
+// [code, null, null] if request failed
+module.exports = async (url) => {
+  const request = new Request(url, {
+    method: 'GET',
+    redirect: 'follow'
+  });
+  const response = await net.fetch(request);
+
+  if (response.ok) {
+    return [response.status, await response.arrayBuffer(), response.headers()];
+  } else {
+    return [response.status, null, null];
+  }
+};


### PR DESCRIPTION
At least I can confirm that `versions.json` retrieval uses proxy now (so that I can boot discord). But I do not know how to force a self-update or modules update, so rest of the update functionalities are untested, for now.

Yeah and I did one of the todos:
> // todo: have these https utils centralised?

net utilities are now centralized.