### PR TITLE
fix: log path not set

### DIFF
--- a/src/paths.js
+++ b/src/paths.js
@@ -4,7 +4,7 @@ const { app } = require('electron');
 
 const buildInfo = require('./utils/buildInfo');
 
-let userData, userDataVersioned, resourcesPath, moduleData, exeDir, installPath;
+let userData, userDataVersioned, resourcesPath, moduleData, exeDir, installPath, logPath;
 
 exports.getUserData = () => userData;
 exports.getUserDataVersioned = () => userDataVersioned;
@@ -12,6 +12,7 @@ exports.getUserDataVersioned = () => userDataVersioned;
 exports.getResources = () => resourcesPath;
 exports.getModuleDataPath = () => moduleData;
 exports.getInstallPath = () => installPath;
+exports.getLogPath = () => logPath;
 
 exports.getExeDir = () => exeDir;
 
@@ -26,7 +27,9 @@ exports.init = () => {
 
   moduleData = buildInfo.newUpdater ? join(userData, 'module_data') : join(userDataVersioned, 'modules');
   resourcesPath = join(process.resourcesPath);
+  logPath = join(userData, 'logs');
 
   global.moduleDataPath = moduleData; // Global because discord
+  global.logPath = logPath; // Global because discord
   app.setPath('userData', userData); // Set userData properly because electron
 };


### PR DESCRIPTION
Fixes #202

I've chosen the `logs` directory since that's what Discord's app.asar already does.

Let me know if anything needs changing.

Relevant code paths (Discord stable 0.0.78):
- core.asar: `app/discord_native/browser/fileManager.js:16`
- app.asar: `app_bootstrap/bootstrap.js:38`
- app.asar: `common/paths.js:84`