### PR TITLE
fix: EnvironmentNotInitialized error

### DIFF
--- a/src/splash/index.js
+++ b/src/splash/index.js
@@ -123,7 +123,8 @@ const initNew = async (inst) => {
     skip_module_delta: {},
     skip_all_module_delta: false,
     skip_windows_arch_update: false,
-    optin_windows_transition_progression: false
+    optin_windows_transition_progression: false,
+    allow_optional_updates: false
   };
 
   while (true) {


### PR DESCRIPTION
This missing retryOptions (`allow_optional_updates`) somehow caused the following crash on Discord Canary:
```
thread '<unnamed>' panicked at B:\b\discord_common\rust\napi\src\class.rs:139:37:
called `Result::unwrap()` on an `Err` value: EnvironmentNotInitialized
```
The default option for it is false, as per: https://github.com/OpenAsar/discord-desktop-datamining/compare/1552624...canary
This also works fine on stable despite the option not existing there yet. So I'd say this is safe to publish in advance to Discord pushing the update to stable.