### PR TITLE
Show pointer cursor on OpenAsar settings link

### DIFF
--- a/src/mainWindow.js
+++ b/src/mainWindow.js
@@ -34,6 +34,7 @@ setInterval(() => {
   const oaVersion = oaVersionInfo.children[0];
   oaVersion.id = 'openasar-ver';
   oaVersion.textContent = 'OpenAsar <channel> (<hash>)';
+  oaVersion.style.cursor = 'pointer';
   oaVersion.onclick = () => DiscordNative.ipc.send('DISCORD_UPDATED_QUOTES', 'o');
 
   oaVersionInfo.textContent = '';


### PR DESCRIPTION
Fixes #245.

## Summary
- show a pointer cursor on the clickable OpenAsar version link
- leave settings routing and sidebar injection unchanged

## Testing
- exercised the settings-injection callback with a DOM mock
- checked all source and script JavaScript syntax
- ran the repository strip and asar packaging flow, then checked the extracted script
- `git diff --check`