### PR TITLE
updater: tolerate read-only module dirs (fixes flatpak boot)

### DIFF
--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -123,7 +123,11 @@ const startUpdate = () => {
 
     require('./firstRun').do();
   } else {
-    moduleUpdater.init(Constants.UPDATE_ENDPOINT, buildInfo);
+    try {
+      moduleUpdater.init(Constants.UPDATE_ENDPOINT, buildInfo);
+    } catch (e) {
+      log('Modules', 'Failed to init module updater', e);
+    }
   }
 
   splash.events.once('APP_SHOULD_LAUNCH', () => {

--- a/src/updater/moduleUpdater.js
+++ b/src/updater/moduleUpdater.js
@@ -61,8 +61,12 @@ exports.init = (endpoint, { releaseChannel, version }) => {
   Module.globalPaths.push(basePath);
 
   // Purge pending
-  fs.rmSync(downloadPath, { recursive: true, force: true });
-  mkdir(downloadPath);
+  try {
+    fs.rmSync(downloadPath, { recursive: true, force: true });
+    mkdir(downloadPath);
+  } catch (e) {
+    log('Modules', 'Failed to init pending directory', e);
+  }
 
   try {
     installed = JSON.parse(fs.readFileSync(manifestPath));
@@ -134,6 +138,23 @@ const downloadModule = async (name, ver) => {
   const path = join(downloadPath, name + '-' + ver + '.zip');
   const file = fs.createWriteStream(path);
 
+  let writeFailed = false;
+  file.on('error', (e) => {
+    if (writeFailed) return;
+    writeFailed = true;
+
+    log('Modules', 'Failed to download', name, e);
+
+    downloading.fail++;
+    downloading.done++;
+
+    events.emit('downloaded-module', { name });
+
+    if (downloading.done === downloading.total) {
+      events.emit('downloaded', { failed: downloading.fail });
+    }
+  });
+
   // log('Modules', 'Downloading', `${name}@${ver}`);
 
   let success, total, cur =  0;
@@ -150,6 +171,8 @@ const downloadModule = async (name, ver) => {
   });
 
   await new Promise((res) => file.on('close', res));
+
+  if (writeFailed) return;
 
   if (success) commitManifest();
     else downloading.fail++;
@@ -268,7 +291,13 @@ exports.quitAndInstallUpdates = () => host.quitAndInstall();
 exports.isInstalled = (n, v) => installed[n] && (skipModule || !(v && installed[n].installedVersion !== v));
 exports.getInstalled = () => ({ ...installed });
 
-const commitManifest = () => fs.writeFileSync(manifestPath, JSON.stringify(installed, null, 2));
+const commitManifest = () => {
+  try {
+    fs.writeFileSync(manifestPath, JSON.stringify(installed, null, 2));
+  } catch (e) {
+    log('Modules', 'Failed to write manifest', e);
+  }
+};
 
 exports.install = (name, def, { version } = {}) => {
   if (exports.isInstalled(name, version)) {


### PR DESCRIPTION
Fixes #244

## The problem

On Flatpak, Discord runs with `localModulesRoot` pointing at `/app/discord/modules` — a **read-only** directory inside the sandbox. `moduleUpdater.init()` creates the `pending` directory **unconditionally**, even when `SKIP_MODULE_UPDATE` is active (which it is here, since the modules are local):

```js
// Purge pending
fs.rmSync(downloadPath, { recursive: true, force: true });
mkdir(downloadPath);
```

This throws `EROFS/ENOENT` — and since `init()` is called from `startUpdate()`, which runs under `app.whenReady().then(startUpdate)` with **no try/catch at all**, the exception aborts the whole startup. Practically speaking: the Discord process starts and stays alive, but **no window is ever created** — no splash, no renderer. Just an orphan process burning memory.

Observed log (Discord 1.0.152 flatpak, Arch Linux):

```
(node:7) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, mkdir '/app/discord/modules/pending'
    at Object.mkdirSync (node:fs:1363:26)
    at mkdir (.../updater/moduleUpdater.js:1:297)
    at exports.init (.../updater/moduleUpdater.js:1:1388)
    at startUpdate (.../bootstrap.js:1:3065)
```

After fixing the boot crash, the optional module downloads (krisp, game_utils, rpc) also surfaced `uncaughtException`s — `createWriteStream` had no error handler and tried to write into the same read-only directory.

## The fix

Four small, conservative changes:

1. **`moduleUpdater.init()`** — the pending-directory purge/creation is now wrapped in try/catch and only logged. The directory is only useful when modules will be downloaded; on read-only filesystems it is useless anyway.
2. **`downloadModule()`** — `createWriteStream` now has an error handler: instead of an `uncaughtException`, the failure is logged and the download tracking is finalized properly (with a `writeFailed` guard to avoid double-counting).
3. **`commitManifest()`** — manifest write guarded against read-only paths.
4. **`bootstrap.js`** — defense in depth: `moduleUpdater.init()` wrapped in try/catch. An updater failure should **never** be able to take down the whole app bootstrap.

## Testing

Validated on Flatpak (Arch Linux, Discord 1.0.152 + Vencord): Discord boots normally, window created, renderer alive:

```
[OpenAsar > Modules] Failed to init pending directory Error: ENOENT: no such file or directory, mkdir '/app/discord/modules/pending'
|  renderer-first-paint:        1645.65
|  renderer-full-interactive:   4810.00
```

The former download `uncaughtException`s became clean logs:

```
[OpenAsar > Modules] Failed to download discord_krisp [Error: ENOENT: no such file or directory, open '/app/discord/modules/pending/discord_krisp-0.zip']
```

On writable systems the behavior is unchanged: the `pending` directory is still created normally and downloads work as before.
